### PR TITLE
Fix version of encore_login in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "url-loader": "^0.5.7",
     "xtend": "^4.0.1",
     "horizon": "^0.3.1",
-    "encore_login": "1.0.0"
+    "encore_login": "0.0.1"
   },
   "devDependencies": {
     "babel-core": "^6.3.19",


### PR DESCRIPTION
I couldn't get this example running as version 1.0.0 of `encore_login` hasn't been published to npm. I'm guessing it should be 0.0.1.
